### PR TITLE
HP-2382 removed space from "Enable" and "Disable" bulk buttons (please use css to align)

### DIFF
--- a/src/views/account/index.php
+++ b/src/views/account/index.php
@@ -88,11 +88,11 @@ $this->params['breadcrumbs'][] = $this->title;
         ];
         if (Yii::$app->user->can('support')) {
             array_unshift($dropDownItems, [
-                'label' => '<i class="fa fa-toggle-on"></i> ' . Yii::t('hipanel', 'Enable block'),
+                'label' => '<i class="fa fa-toggle-on"></i>' . Yii::t('hipanel', 'Enable block'),
                 'linkOptions' => ['data-toggle' => 'modal'],
                 'url' => '#bulk-enable-block-modal',
             ],[
-                'label' => '<i class="fa fa-toggle-off"></i> ' . Yii::t('hipanel', 'Disable block'),
+                'label' => '<i class="fa fa-toggle-off"></i>' . Yii::t('hipanel', 'Disable block'),
                 'url' => '#bulk-disable-block-modal',
                 'linkOptions' => ['data-toggle' => 'modal'],
             ]);

--- a/src/views/account/index.php
+++ b/src/views/account/index.php
@@ -69,7 +69,7 @@ $this->params['breadcrumbs'][] = $this->title;
         <?php
         $dropDownItems = [
             [
-                'label' => '<i class="fa fa-trash"></i> ' . Yii::t('hipanel', 'Delete'),
+                'label' => '<i class="fa fa-trash"></i>' . Yii::t('hipanel', 'Delete'),
                 'url' => '#bulk-delete-modal',
                 'linkOptions' => ['data-toggle' => 'modal'],
             ],

--- a/src/views/hdomain/index.php
+++ b/src/views/hdomain/index.php
@@ -76,12 +76,12 @@ $this->params['breadcrumbs'][] = $this->title;
                     'options' => ['class' => 'pull-right'],
                     'items' => [
                         [
-                            'label' => '<i class="fa fa-toggle-on"></i> ' . Yii::t('hipanel', 'Enable'),
+                            'label' => '<i class="fa fa-toggle-on"></i>' . Yii::t('hipanel', 'Enable'),
                             'linkOptions' => ['data-toggle' => 'modal'],
                             'url' => '#bulk-enable-block-modal',
                         ],
                         [
-                            'label' => '<i class="fa fa-toggle-off"></i> ' . Yii::t('hipanel', 'Disable'),
+                            'label' => '<i class="fa fa-toggle-off"></i>' . Yii::t('hipanel', 'Disable'),
                             'url' => '#bulk-disable-block-modal',
                             'linkOptions' => ['data-toggle' => 'modal'],
                         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Refined the visual spacing in dropdown menu items for enabling and disabling domains, resulting in a more consistent and compact display.
	- Improved the formatting of labels in the bulk actions section for enabling and disabling blocks, enhancing visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->