### PR TITLE
HP-2644: Moved code responsible for Grid rendering outside `SynchronousCountEnabler` class

### DIFF
--- a/src/controllers/BackupingController.php
+++ b/src/controllers/BackupingController.php
@@ -19,12 +19,11 @@ use hipanel\actions\VariantsAction;
 use hipanel\actions\ViewAction;
 use hipanel\filters\EasyAccessControl;
 use hipanel\modules\hosting\widgets\backuping\DiskUsageTotalWidget;
-use yii\grid\GridView;
+use hipanel\widgets\DataProviderGridRenderer;
 use hipanel\helpers\ArrayHelper;
 use hipanel\models\Ref;
 use hipanel\modules\hosting\models\Backuping;
 use hipanel\modules\hosting\models\BackupSearch;
-use hipanel\widgets\SynchronousCountEnabler;
 use Yii;
 
 class BackupingController extends \hipanel\base\CrudController
@@ -65,7 +64,7 @@ class BackupingController extends \hipanel\base\CrudController
                 'responseVariants' => [
                     IndexAction::VARIANT_SUMMARY_RESPONSE => static function (VariantsAction $action): string {
                         $dataProvider = $action->parent->getDataProvider();
-                        $defaultSummary = (new SynchronousCountEnabler($dataProvider, fn(GridView $grid): string => $grid->renderSummary()))();
+                        $defaultSummary = (new DataProviderGridRenderer($dataProvider))->renderSummary();
 
                         return $defaultSummary . DiskUsageTotalWidget::widget([
                             'rows' => $dataProvider->query->all(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized summary rendering on the backups index to improve responsiveness and reduce load times, especially with large datasets. No visible UI changes.
  * Maintains existing total disk usage display while improving the efficiency of how summary data is produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->